### PR TITLE
few benchmark nitpicks

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -7,12 +7,15 @@ ifeq ($(UNAME_S),Darwin)
 	SED = gsed
 endif
 
+BENCH_COUNT ?= 10
+BENCH_TIME ?= 1s
+
 all: bench analyze
 
 bench:
-	go test -bench=BenchmarkGoART -benchmem -count=10 > art.txt
-	go test -bench=BenchmarkGoAdaptiveRadixTree -benchmem -count=10 > gart.txt
-	go test -bench=BenchmarkOriginalGoART -benchmem -count=10 > oart.txt
+	go test -bench=BenchmarkGoART -benchmem -count=${BENCH_COUNT} -benchtime=${BENCH_TIME} | tee art.txt
+	go test -bench=BenchmarkGoAdaptiveRadixTree -benchmem -count=${BENCH_COUNT} -benchtime=${BENCH_TIME} | tee gart.txt
+	go test -bench=BenchmarkOriginalGoART -benchmem -count=${BENCH_COUNT} -benchtime=${BENCH_TIME} | tee oart.txt
 
 analyze:
 	@${SED} -i 's/BenchmarkGoART/Benchmark/g' art.txt

--- a/bench/main_test.go
+++ b/bench/main_test.go
@@ -58,6 +58,7 @@ func BenchmarkGoARTUpdate(b *testing.B) {
 		})
 	}
 }
+
 func BenchmarkOriginalGoARTUpdate(b *testing.B) {
 	tree := oart.NewArtTree()
 
@@ -77,6 +78,7 @@ func BenchmarkOriginalGoARTUpdate(b *testing.B) {
 		})
 	}
 }
+
 func BenchmarkGoAdaptiveRadixTreeUpdate(b *testing.B) {
 	tree := gart.New()
 
@@ -107,14 +109,16 @@ func BenchmarkGoARTInsert(b *testing.B) {
 				w := words[i]
 				tree.Insert(w, w)
 
-				if i == size-1 {
+				i = (i + 1) % size
+
+				if i == 0 {
 					tree = art.NewAlphaSortedTree[[]byte, []byte]()
 				}
-				i = (i + 1) % size
 			}
 		})
 	}
 }
+
 func BenchmarkGoAdaptiveRadixTreeInsert(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("insert_size_%d", size), func(b *testing.B) {
@@ -125,14 +129,16 @@ func BenchmarkGoAdaptiveRadixTreeInsert(b *testing.B) {
 				w := words[i]
 				tree.Insert(w, w)
 
-				if i == size-1 {
+				i = (i + 1) % size
+
+				if i == 0 {
 					tree = gart.New()
 				}
-				i = (i + 1) % size
 			}
 		})
 	}
 }
+
 func BenchmarkOriginalGoARTInsert(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("insert_size_%d", size), func(b *testing.B) {
@@ -143,10 +149,11 @@ func BenchmarkOriginalGoARTInsert(b *testing.B) {
 				w := words[i]
 				tree.Insert(w, w)
 
-				if i == size-1 {
+				i = (i + 1) % size
+
+				if i == 0 {
 					tree = oart.NewArtTree()
 				}
-				i = (i + 1) % size
 			}
 		})
 	}
@@ -171,6 +178,7 @@ func BenchmarkGoARTSearch(b *testing.B) {
 		})
 	}
 }
+
 func BenchmarkGoAdaptiveRadixTreeSearch(b *testing.B) {
 	tree := gart.New()
 
@@ -190,6 +198,7 @@ func BenchmarkGoAdaptiveRadixTreeSearch(b *testing.B) {
 		})
 	}
 }
+
 func BenchmarkOriginalGoARTSearch(b *testing.B) {
 	tree := oart.NewArtTree()
 


### PR DESCRIPTION
Couple of Makefile changes to make it possible to just run quick test controlling count and benchtime.

Changed `>file.txt` to ` | tee file.txt`, so the progress is visible.

Reordered `i = (i + 1) % size` and reset, because it's a bit more readable to compare to `0` than to `size-1`.

As a little suggestion, if you had Reset on your trees, you could save some allocs.